### PR TITLE
fix: resolve antigg nuking all chat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,17 @@ repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
     maven { url "https://repo.sk1er.club/repository/maven-public" }
-    maven {
-        credentials {
-            username "$nexus_user"
-            password "$nexus_password"
+
+    if (project.hasProperty("nexus_user") && project.hasProperty("nexus_password")) {
+        maven {
+            credentials {
+                username "$nexus_user"
+                password "$nexus_password"
+            }
+            url "https://repo.sk1er.club/repository/maven-private"
         }
-        url "https://repo.sk1er.club/repository/maven-private"
     }
+    
     maven { url 'https://repo.spongepowered.org/maven' }
 }
 def FABRIC = fabric
@@ -279,7 +283,7 @@ dependencies {
     }
 
     embed "gg.essential:loader-launchwrapper:1.0.2"
-    implementation "gg.essential:Essential:1149-${mcVersion}-SNAPSHOT"
+    implementation "gg.essential:Essential:1194-${mcVersion}-SNAPSHOT"
 
     // FG already adds this even though it is not available at runtime, so we need to manually list it to bundle it
     if (VANILLA) {

--- a/build.gradle
+++ b/build.gradle
@@ -50,17 +50,6 @@ repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
     maven { url "https://repo.sk1er.club/repository/maven-public" }
-
-    if (project.hasProperty("nexus_user") && project.hasProperty("nexus_password")) {
-        maven {
-            credentials {
-                username "$nexus_user"
-                password "$nexus_password"
-            }
-            url "https://repo.sk1er.club/repository/maven-private"
-        }
-    }
-    
     maven { url 'https://repo.spongepowered.org/maven' }
 }
 def FABRIC = fabric
@@ -163,6 +152,7 @@ minecraft {
 
         runDir = "run"
         makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+        clientRunArgs += ["--tweakClass=gg.essential.loader.stage0.EssentialSetupTweaker"]
     }
     if (FG3) {
         mappings channel: 'snapshot', version: '20200220-1.15.1'
@@ -283,7 +273,7 @@ dependencies {
     }
 
     embed "gg.essential:loader-launchwrapper:1.0.2"
-    implementation "gg.essential:Essential:1207-${mcVersion}-SNAPSHOT"
+    implementation "gg.essential:Essential:1221-${mcVersion}-SNAPSHOT"
 
     // FG already adds this even though it is not available at runtime, so we need to manually list it to bundle it
     if (VANILLA) {

--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ dependencies {
     }
 
     embed "gg.essential:loader-launchwrapper:1.0.2"
-    implementation "gg.essential:Essential:1194-${mcVersion}-SNAPSHOT"
+    implementation "gg.essential:Essential:1207-${mcVersion}-SNAPSHOT"
 
     // FG already adds this even though it is not available at runtime, so we need to manually list it to bundle it
     if (VANILLA) {

--- a/src/main/java/club/sk1er/mods/autogg/AutoGG.java
+++ b/src/main/java/club/sk1er/mods/autogg/AutoGG.java
@@ -21,6 +21,7 @@ package club.sk1er.mods.autogg;
 import club.sk1er.mods.autogg.command.AutoGGCommand;
 import club.sk1er.mods.autogg.config.AutoGGConfig;
 import club.sk1er.mods.autogg.handlers.gg.AutoGGHandler;
+import club.sk1er.mods.autogg.handlers.patterns.PlaceholderAPI;
 import club.sk1er.mods.autogg.tasks.RetrieveTriggersTask;
 import club.sk1er.mods.autogg.tasks.data.TriggersSchema;
 import gg.essential.api.EssentialAPI;
@@ -33,6 +34,8 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+
+import java.util.*;
 
 /**
  * Contains the main class for AutoGG which handles trigger schema setting/getting and the main initialization code.
@@ -61,6 +64,12 @@ public class AutoGG {
     public void onFMLInitialization(FMLInitializationEvent event) {
         autoGGConfig = new AutoGGConfig();
         autoGGConfig.preload();
+
+        Set<String> joined = new HashSet<>();
+        joined.addAll(Arrays.asList(primaryGGStrings));
+        joined.addAll(Arrays.asList(secondaryGGStrings));
+
+        PlaceholderAPI.INSTANCE.registerPlaceHolder("antigg_strings", String.join("|", joined));
 
         Multithreading.runAsync(new RetrieveTriggersTask());
         MinecraftForge.EVENT_BUS.register(new AutoGGHandler());

--- a/src/main/java/club/sk1er/mods/autogg/detectors/branding/ServerBrandingDetector.java
+++ b/src/main/java/club/sk1er/mods/autogg/detectors/branding/ServerBrandingDetector.java
@@ -7,6 +7,6 @@ import net.minecraft.client.Minecraft;
 public class ServerBrandingDetector implements IDetector {
     @Override
     public boolean detect(String data) {
-        return Minecraft.getMinecraft().thePlayer != null && PatternHandler.INSTANCE.getPattern(data).matcher(Minecraft.getMinecraft().thePlayer.getClientBrand()).matches();
+        return Minecraft.getMinecraft().thePlayer != null && PatternHandler.INSTANCE.getOrRegisterPattern(data).matcher(Minecraft.getMinecraft().thePlayer.getClientBrand()).matches();
     }
 }

--- a/src/main/java/club/sk1er/mods/autogg/detectors/ip/ServerIPDetector.java
+++ b/src/main/java/club/sk1er/mods/autogg/detectors/ip/ServerIPDetector.java
@@ -7,6 +7,6 @@ import net.minecraft.client.Minecraft;
 public class ServerIPDetector implements IDetector {
     @Override
     public boolean detect(String data) {
-        return Minecraft.getMinecraft().thePlayer != null && PatternHandler.INSTANCE.getPattern(data).matcher(Minecraft.getMinecraft().getCurrentServerData().serverIP).matches();
+        return Minecraft.getMinecraft().thePlayer != null && PatternHandler.INSTANCE.getOrRegisterPattern(data).matcher(Minecraft.getMinecraft().getCurrentServerData().serverIP).matches();
     }
 }

--- a/src/main/java/club/sk1er/mods/autogg/handlers/gg/AutoGGHandler.java
+++ b/src/main/java/club/sk1er/mods/autogg/handlers/gg/AutoGGHandler.java
@@ -6,6 +6,7 @@ import club.sk1er.mods.autogg.tasks.data.Server;
 import club.sk1er.mods.autogg.tasks.data.Trigger;
 import gg.essential.api.utils.Multithreading;
 import net.minecraft.client.Minecraft;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -46,12 +47,14 @@ public class AutoGGHandler {
 
     @SubscribeEvent
     public void onClientChatReceived(ClientChatReceivedEvent event) {
+        String stripped = EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText());
+
         if (AutoGG.INSTANCE.getAutoGGConfig().isModEnabled() && server != null) {
             for (Trigger trigger : server.getTriggers()) {
                 switch (trigger.getType()) {
                     case ANTI_GG:
                         if (AutoGG.INSTANCE.getAutoGGConfig().isAntiGGEnabled()) {
-                            if (PatternHandler.INSTANCE.getPattern(trigger.getPattern()).matcher(event.message.getUnformattedText()).matches()) {
+                            if (PatternHandler.INSTANCE.getOrRegisterPattern(trigger.getPattern()).matcher(stripped).matches()) {
                                 event.setCanceled(true);
                                 return;
                             }
@@ -59,7 +62,7 @@ public class AutoGGHandler {
                         break;
                     case ANTI_KARMA:
                         if (AutoGG.INSTANCE.getAutoGGConfig().isAntiKarmaEnabled()) {
-                            if (PatternHandler.INSTANCE.getPattern(trigger.getPattern()).matcher(event.message.getUnformattedText()).matches()) {
+                            if (PatternHandler.INSTANCE.getOrRegisterPattern(trigger.getPattern()).matcher(stripped).matches()) {
                                 event.setCanceled(true);
                                 return;
                             }
@@ -69,12 +72,11 @@ public class AutoGGHandler {
             }
 
             Multithreading.runAsync(() -> {
-                String chatMessage = event.message.getUnformattedText();
                 // Casual GG feature
                 for (Trigger trigger : server.getTriggers()) {
                     switch (trigger.getType()) {
                         case NORMAL:
-                            if (PatternHandler.INSTANCE.getPattern(trigger.getPattern()).matcher(chatMessage).matches()) {
+                            if (PatternHandler.INSTANCE.getOrRegisterPattern(trigger.getPattern()).matcher(stripped).matches()) {
                                 invokeGG();
                                 return;
                             }
@@ -82,7 +84,7 @@ public class AutoGGHandler {
 
                         case CASUAL:
                             if (AutoGG.INSTANCE.getAutoGGConfig().isCasualAutoGGEnabled()) {
-                                if (PatternHandler.INSTANCE.getPattern(trigger.getPattern()).matcher(chatMessage).matches()) {
+                                if (PatternHandler.INSTANCE.getOrRegisterPattern(trigger.getPattern()).matcher(stripped).matches()) {
                                     invokeGG();
                                     return;
                                 }

--- a/src/main/java/club/sk1er/mods/autogg/handlers/patterns/PatternHandler.java
+++ b/src/main/java/club/sk1er/mods/autogg/handlers/patterns/PatternHandler.java
@@ -1,7 +1,9 @@
 package club.sk1er.mods.autogg.handlers.patterns;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -11,28 +13,21 @@ import java.util.regex.Pattern;
  */
 public class PatternHandler {
     public static PatternHandler INSTANCE = new PatternHandler();
-    private final List<Pattern> patterns = new ArrayList<>();
 
-    public Pattern registerPattern(String pattern) {
-        Pattern p = Pattern.compile(pattern);
-        if (!patterns.contains(p)) {
-            patterns.add(p);
+    private final Map<String, Pattern> patternCache = new HashMap<>();
+
+    public Pattern getOrRegisterPattern(String pattern) {
+        String processedPattern = PlaceholderAPI.INSTANCE.process(pattern);
+
+        Pattern p = patternCache.get(processedPattern);
+        if (p == null) {
+            p = patternCache.put(processedPattern, Pattern.compile(processedPattern));
         }
 
         return p;
     }
 
-    public Pattern getPattern(String pattern) {
-        for (Pattern pattern1 : patterns) {
-            if (pattern1.pattern().equals(pattern)) {
-                return pattern1;
-            }
-        }
-
-        return registerPattern(pattern);
-    }
-
     public void clearPatterns() {
-        patterns.clear();
+        patternCache.clear();
     }
 }

--- a/src/main/java/club/sk1er/mods/autogg/handlers/patterns/PlaceholderAPI.java
+++ b/src/main/java/club/sk1er/mods/autogg/handlers/patterns/PlaceholderAPI.java
@@ -1,0 +1,26 @@
+package club.sk1er.mods.autogg.handlers.patterns;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PlaceholderAPI {
+    public static PlaceholderAPI INSTANCE = new PlaceholderAPI();
+    private static final String PLACEHOLDER = "${%s}";
+
+    private final Map<String, String> placeholders = new HashMap<>();
+
+    public void registerPlaceHolder(String key, String value) {
+        placeholders.put(key, value);
+    }
+
+    public String process(String string) {
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            String placeholder = String.format(PLACEHOLDER, entry.getKey());
+            if (string.contains(placeholder)) {
+                string = string.replace(placeholder, entry.getValue());
+            }
+        }
+
+        return string;
+    }
+}

--- a/src/main/java/club/sk1er/mods/autogg/tasks/RetrieveTriggersTask.java
+++ b/src/main/java/club/sk1er/mods/autogg/tasks/RetrieveTriggersTask.java
@@ -4,16 +4,11 @@ import club.sk1er.mods.autogg.AutoGG;
 import club.sk1er.mods.autogg.handlers.patterns.PatternHandler;
 import club.sk1er.mods.autogg.tasks.data.Server;
 import club.sk1er.mods.autogg.tasks.data.Trigger;
-import club.sk1er.mods.autogg.tasks.data.TriggerType;
 import club.sk1er.mods.autogg.tasks.data.TriggersSchema;
 import com.google.gson.Gson;
 import gg.essential.api.utils.WebUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Runnable class to fetch the AutoGG triggers on startup.

--- a/src/main/java/club/sk1er/mods/autogg/tasks/RetrieveTriggersTask.java
+++ b/src/main/java/club/sk1er/mods/autogg/tasks/RetrieveTriggersTask.java
@@ -36,24 +36,17 @@ public class RetrieveTriggersTask implements Runnable {
         try {
             AutoGG.INSTANCE.setTriggers(gson.fromJson(WebUtil.fetchString(TRIGGERS_URL), TriggersSchema.class));
         } catch (Exception e) {
-            // To stop maniac in the event of the triggers being failed to reach we just create an empty TriggerSchema.
+            // Prevent the game from melting when the triggers are not available
             LOGGER.error("Failed to fetch the AutoGG triggers! This isn't good...", e);
             AutoGG.INSTANCE.setTriggers(new TriggersSchema(new Server[0]));
             e.printStackTrace();
         }
 
         LOGGER.info("Registering patterns...");
-        List<String> joined = new ArrayList<>();
-        joined.addAll(Arrays.asList(AutoGG.INSTANCE.getPrimaryGGStrings()));
-        joined.addAll(Arrays.asList(AutoGG.INSTANCE.getSecondaryGGStrings()));
-
         for (Server server : AutoGG.INSTANCE.getTriggers().getServers()) {
             for (Trigger trigger : server.getTriggers()) {
                 String pattern = trigger.getPattern();
-                if (trigger.getType() == TriggerType.ANTI_GG) {
-                    pattern = pattern.replace("${antigg_strings}", String.join("|", joined));
-                }
-                PatternHandler.INSTANCE.registerPattern(pattern);
+                PatternHandler.INSTANCE.getOrRegisterPattern(pattern);
             }
         }
     }


### PR DESCRIPTION
Fix #20 and a stacktrace caused by placeholders in the AntiGG regexes

- [x] Reproduce issue
- [x] Fix crash caused by AntiGG
- [x] Fix messages disappearing from chat (This was due to a bad regex which can be fixed server-side)